### PR TITLE
Fix dead links

### DIFF
--- a/src/App/Body/Body.tsx
+++ b/src/App/Body/Body.tsx
@@ -169,8 +169,8 @@ You can also customize the pages without touching React using CSS, [SCSS](https:
           },
           {
             title: "Easily testable",
-            description: `Test your theme [in storybook](https://docs.keycloakify.dev/testing-your-theme/in-storybook) or 
-                in [a local Keycloak container](https://docs.keycloakify.dev/testing-your-theme/in-a-keycloak-docker-container) with a simple command.`,
+            description: `Test your theme [in storybook](https://docs.keycloakify.dev/testing-your-theme/outside-of-keycloak) or 
+                in [a local Keycloak container](https://docs.keycloakify.dev/testing-your-theme/inside-of-keycloak) with a simple command.`,
           },
           {
             title: "We are here to help!",

--- a/src/App/Body/Body.tsx
+++ b/src/App/Body/Body.tsx
@@ -70,8 +70,8 @@ Wouldn't it be great if we could just design the login and register pages as if 
       <GlArticle
         title="Using React is just an option"
         body={`Keycloakify is first and foremost a tool to help you 
-build and test your theme in [Storybook](https://docs.keycloakify.dev/testing-your-theme/in-storybook) or 
-in a local [Keycloak container](https://docs.keycloakify.dev/testing-your-theme/in-a-keycloak-docker-container) with hot-reload.  
+build and test your theme in [Storybook](https://docs.keycloakify.dev/testing-your-theme/outside-of-keycloak) or 
+in a local [Keycloak container](https://docs.keycloakify.dev/testing-your-theme/inside-of-keycloak) with hot-reload.  
 You can use React if you want to use your own components or fancy libraries like [MUI](https://mui.com/joy-ui/getting-started/templates/sign-in-side/) or [Shadcn/ui](https://ui.shadcn.com/examples/authentication) 
 but it's not mandatory.  
 You can also customize the pages without touching React using CSS, [SCSS](https://sass-lang.com/), [Tailwind](https://tailwindcss.com/), 


### PR DESCRIPTION
Updated links in the article body to point to the correct documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the "Using React is just an option" article: replaced prior theme-testing links with two clearer variants — outside-of-keycloak and inside-of-keycloak.
  * Revised the "Easily testable" checklist item to reference the new outside/inside-of-keycloak guidance and updated phrasing for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->